### PR TITLE
Add postgresql_pgdg_repo variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Role Variables
 
 ---
 
+postgresql_pgdg_repo: define if you wish to setup the PostgreSQL Global Development Group (PGDG) APT repository
 postgresql_server_install: define if you wish to install postgresql server
 postgresql_client_install: define if you wish to install postgresql client
 postgresql_pkg_version: define the postgresql version

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-
+postgresql_pgdg_repo: true
 postgresql_server_install: true
 postgresql_client_install: true
 postgresql_pkg_version: 9.4

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -4,10 +4,12 @@
   apt_key:
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     id: ACCC4CF8
+  when: postgresql_pgdg_repo
 
 - name: add APT repository
   apt_repository:
     repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ postgresql_pkg_version }}'
+  when: postgresql_pgdg_repo
 
 - name: install postgresql server
   apt:


### PR DESCRIPTION
define if you wish to setup the PostgreSQL
Global Development Group (PGDG) repository

defaults to yes

use case: we mirror all external repositories on a private server
